### PR TITLE
Keep overdue bar chart bars red on hover

### DIFF
--- a/site/styles.css
+++ b/site/styles.css
@@ -1172,7 +1172,7 @@ a.drawer-audit-link:hover { text-decoration: underline; }
 }
 .bar-col:hover .bar-fill { background: var(--info); }
 .bar-fill--overdue { background: #b07070; }
-.bar-col:hover .bar-fill--overdue { background: #c08080; }
+.bar-col:hover .bar-fill--overdue { background: #b07070; }
 .bar-count {
   font-size: 0.64rem;
   color: var(--ink);


### PR DESCRIPTION
Past-month bars now hold `#b07070` on hover instead of lightening, making overdue months visually distinct at a glance.