### PR TITLE
Fix overdue bar color: double-class selector

### DIFF
--- a/site/styles.css
+++ b/site/styles.css
@@ -1171,8 +1171,8 @@ a.drawer-audit-link:hover { text-decoration: underline; }
   padding-bottom: 1px;
 }
 .bar-col:hover .bar-fill { background: var(--info); }
-.bar-fill--overdue { background: #b07070; }
-.bar-col:hover .bar-fill--overdue { background: #b07070; }
+.bar-fill.bar-fill--overdue { background: #b07070; }
+.bar-col:hover .bar-fill.bar-fill--overdue { background: #b07070; }
 .bar-count {
   font-size: 0.64rem;
   color: var(--ink);


### PR DESCRIPTION
 was declared before  in the stylesheet, so same-specificity  (grey) was winning. Using  raises specificity to 0,2,0.