### PR TITLE
Rename 'Policy Ownership' section to 'Ownership'

### DIFF
--- a/site/dashboard.html
+++ b/site/dashboard.html
@@ -166,7 +166,7 @@
     <div class="panel">
       <div class="panel-header">
         <div>
-          <h2>Policy Ownership</h2>
+          <h2>Ownership</h2>
           <p class="panel-subtitle">Accountability and review risk by policy owner.</p>
         </div>
         <div style="display:flex;gap:8px;align-items:center;">


### PR DESCRIPTION
Shorter label, consistent with other section headings.